### PR TITLE
Use Jackson 2 API plugin for XML parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
-            <version>2.12.4-rc199.cb832da5f764</version> <!-- TODO https://github.com/jenkinsci/jackson2-api-plugin/pull/82 -->
+            <version>2.12.4</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,35 @@
             <artifactId>azure-identity</artifactId>
             <version>1.3.1</version>
             <exclusions>
+                <!--
+                    Rely on the Jackson 2 API plugin for Jackson and StAX, excluding all other StAX
+                    APIs and implementations.
+                -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-xml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml</groupId>
+                    <artifactId>aalto-xml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.stream</groupId>
+                    <artifactId>stax-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>stax2-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>stax</groupId>
+                    <artifactId>stax</artifactId>
+                </exclusion>
+
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
@@ -98,6 +127,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
+            <version>2.12.4-rc199.cb832da5f764</version> <!-- TODO https://github.com/jenkinsci/jackson2-api-plugin/pull/82 -->
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jackson2-api-plugin#82

Tested as follows:

- Jenkins core with jenkinsci/jenkins#5604
- `java -jar jenkins.war`
- Install default plugins
- Update `jackson2-api` with latest incremental
- Update `azure-sdk` with the changes from this PR
- Start Azurite emulator
- Go to http://127.0.0.1:8080/credentials/store/system/domain/_/newCredentials
- Add new Azure Storage credential using `devstoreaccount1`, `http://127.0.0.1:10000/devstoreaccount1/`, and the emulator key
- Click "Verify Configuration"
- See "Validation Successful" message

Note: With this change, `azure-sdk` no longer bundles the following JARs:

- `aalto-xml-1.0.0.jar`
- `jackson-dataformat-xml-2.12.3.jar`
- `stax-1.2.0.jar`
- `stax2-api-4.2.1.jar`
- `woodstox-core-6.2.4.jar`