### PR TITLE
Fix list of non proxy hosts

### DIFF
--- a/src/main/java/io/jenkins/plugins/azuresdk/HttpClientRetriever.java
+++ b/src/main/java/io/jenkins/plugins/azuresdk/HttpClientRetriever.java
@@ -10,6 +10,9 @@ import jenkins.model.Jenkins;
 import jenkins.util.JenkinsJVM;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import jenkins.util.SystemProperties;
 
 public class HttpClientRetriever {
@@ -40,7 +43,11 @@ public class HttpClientRetriever {
             }
             String noProxyHost = Util.fixEmpty(proxy.getNoProxyHost());
             if (noProxyHost != null) {
-                proxyOptions.setNonProxyHosts(noProxyHost);
+                // com.azure.core.http.ProxyOptions accepts a '|' delimited String
+                // https://learn.microsoft.com/en-us/java/api/com.azure.core.http.proxyoptions?view=azure-java-stable#com-azure-core-http-proxyoptions-setnonproxyhosts(java-lang-string)
+                proxyOptions.setNonProxyHosts(Arrays.stream(noProxyHost.split("[ \t\n,|]+"))
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.joining("|")));
             }
         }
 


### PR DESCRIPTION
See https://github.com/jenkinsci/azure-vm-agents-plugin/issues/446 and https://learn.microsoft.com/en-us/java/api/com.azure.core.http.proxyoptions?view=azure-java-stable#com-azure-core-http-proxyoptions-setnonproxyhosts(java-lang-string).
List of Non Proxy hosts passed to `ProxyOptions.setNonProxyHosts` was not `|` delimited.

### Testing done

I do not have an environment to test this at the moment.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```